### PR TITLE
Added missing stub subroutines to no_comm.f90

### DIFF
--- a/Sources/no_comm.f90
+++ b/Sources/no_comm.f90
@@ -43,6 +43,15 @@ end
 
 
 !-----------------------------------------------------------------------
+subroutine abort_parallel(info)
+!-----------------------------------------------------------------------
+implicit none
+integer :: info
+return
+end
+
+
+!-----------------------------------------------------------------------
 subroutine comm_rank( myid, world )
 !-----------------------------------------------------------------------
 implicit none
@@ -216,6 +225,24 @@ subroutine clrecv(mesg_tag,mesg_buff,size,pid)
 !-----------------------------------------------------------------------
 integer :: mesg_tag,size,bufid,pid
 logical :: mesg_buff(*)
+return
+end
+
+
+!-----------------------------------------------------------------------
+subroutine cdrecvs(mesg_tag,mesg_buff,size,source,pid)
+!-----------------------------------------------------------------------
+integer :: mesg_tag,size,source,pid
+real*8  :: mesg_buff(*)
+return
+end
+
+
+!-----------------------------------------------------------------------
+subroutine cirecvs(mesg_tag,mesg_buff,size,source,pid)
+!-----------------------------------------------------------------------
+integer :: mesg_tag,size,source,pid
+integer :: mesg_buff(*)
 return
 end
 


### PR DESCRIPTION
Several subroutines existed in mpi_comm.f90, but not in no_comm.f90.
Those subroutines are called at various places in the code, leading
to undefined symbols at link time when compiling without MPI (or PVM).
This commit adds stubs for the undefined symbols to no_comm.f90.

Signed-off-by: william.r.dieter <william.r.dieter@intel.com>